### PR TITLE
Bugfix/relative glossary link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stijn-dejongh/docsify-glossary",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple glossary plugin for docsify, forked from the original work by TheGreenToaster",
   "main": "dist/docsify-glossary.js",
   "unpkg": "dist/docsify-tabs.min.js",

--- a/src/main/js/configuration.js
+++ b/src/main/js/configuration.js
@@ -6,6 +6,7 @@ export class GlossaryConfigurationBuilder {
     glossaryLocation = '';
     debug = false;
     replaceTitleTerms = true;
+    linkPrefix = '';
     constructor() {
         this.terminologyHeading = DEFAULT_TERM_HEADING;
         this.glossaryLocation = DEFAULT_GLOSSARY_FILE_NAME;
@@ -18,6 +19,11 @@ export class GlossaryConfigurationBuilder {
 
     withGlossaryLocation(glossaryLocation) {
         this.glossaryLocation = glossaryLocation;
+        return this;
+    }
+
+    withLinkPrefix(linkPrefix) {
+        this.linkPrefix = linkPrefix;
         return this;
     }
 
@@ -42,6 +48,7 @@ export function configFromYaml(configurationYaml) {
             .withGlossaryLocation(configurationYaml.glossaryLocation ?? DEFAULT_GLOSSARY_FILE_NAME)
             .withDebugEnabled(configurationYaml.debug ?? false)
             .withTitleTermReplacement(configurationYaml.replaceTitleTerms ?? true)
+            .withLinkPrefix(configurationYaml.linkPrefix ?? '')
             .build();
 }
 

--- a/src/main/js/glossary.js
+++ b/src/main/js/glossary.js
@@ -9,7 +9,10 @@ function replaceTermInLine(term, contentLine, linkId, config) {
     let reComma = new RegExp(`\\s(${term}),`, 'ig');
     let reFullStop = new RegExp(`\\s(${term})\\.`, 'ig');
 
-    let link = ` [$1](/${config.glossaryLocation.replace('.md', '')}?id=${linkId})`;
+    let compiledLink = config.glossaryLocation
+            .replace('./', `${config.linkPrefix}/`)
+            .replace('.md', '');
+    let link = ` [$1](/${compiledLink}?id=${linkId})`;
 
     let replacement = contentLine.replace(reComma, link + ',')
             .replace(re, link + ' ')

--- a/src/test/js/glossary_test.spec.js
+++ b/src/test/js/glossary_test.spec.js
@@ -220,22 +220,22 @@ describe('Glossary location', () => {
         expect([...result.matchAll(`${glossaryLocation}\\?id=api`)]).toHaveLength(2);
     });
 
-  //   Issue with links referring to relative paths after compilation
-  // example case:
-  //    glossaryLocation: ./X_Appendix/Glossary/HOME.md
-  //    resulting link: http://localhost:3000/#/./X_Appendix/Glossary/HOME?id=practices
-  it(' can handle relative link configurations', () => {
-    let glossaryLocation = './alternate/location/glossary/README';
-    config = glossifyConfig()
-      .withGlossaryLocation(glossaryLocation+'.md')
-      .withLinkPrefix('#')
-      .build();
+    //   Issue with links referring to relative paths after compilation
+    // example case:
+    //    glossaryLocation: ./X_Appendix/Glossary/HOME.md
+    //    resulting link: http://localhost:3000/#/./X_Appendix/Glossary/HOME?id=practices
+    it(' can handle relative link configurations', () => {
+        let glossaryLocation = './alternate/location/glossary/README';
+        config = glossifyConfig()
+                .withGlossaryLocation(glossaryLocation+'.md')
+                .withLinkPrefix('#')
+                .build();
 
-    dictionary = loadTerminology(sourceText, config);
-    expect(dictionary['API']).toBeTruthy();
+        dictionary = loadTerminology(sourceText, config);
+        expect(dictionary['API']).toBeTruthy();
 
-    let result = addLinks(textWithTerminologyUsage, dictionary, config);
-    expect([...result.matchAll(`#/alternate/location/glossary/README/\\?id=api`)]).toHaveLength(2);
-  });
+        let result = addLinks(textWithTerminologyUsage, dictionary, config);
+        expect([...result.matchAll('/#/alternate/location/glossary/README\\?id=api')]).toHaveLength(2);
+    });
 });
 

--- a/src/test/js/glossary_test.spec.js
+++ b/src/test/js/glossary_test.spec.js
@@ -219,5 +219,23 @@ describe('Glossary location', () => {
 
         expect([...result.matchAll(`${glossaryLocation}\\?id=api`)]).toHaveLength(2);
     });
+
+  //   Issue with links referring to relative paths after compilation
+  // example case:
+  //    glossaryLocation: ./X_Appendix/Glossary/HOME.md
+  //    resulting link: http://localhost:3000/#/./X_Appendix/Glossary/HOME?id=practices
+  it(' can handle relative link configurations', () => {
+    let glossaryLocation = './alternate/location/glossary/README';
+    config = glossifyConfig()
+      .withGlossaryLocation(glossaryLocation+'.md')
+      .withLinkPrefix('#')
+      .build();
+
+    dictionary = loadTerminology(sourceText, config);
+    expect(dictionary['API']).toBeTruthy();
+
+    let result = addLinks(textWithTerminologyUsage, dictionary, config);
+    expect([...result.matchAll(`#/alternate/location/glossary/README/\\?id=api`)]).toHaveLength(2);
+  });
 });
 


### PR DESCRIPTION
- Fix interpretation of relative links when replacing terminology
- Add configuration parameter to set replacement link prefixes
  - for use with custom set-ups (such as c4builder variant of docsify)