### PR TITLE
Do not replace inside markdown links

### DIFF
--- a/src/main/js/glossary.js
+++ b/src/main/js/glossary.js
@@ -4,20 +4,15 @@ function replaceTermInLine(term, contentLine, linkId, config) {
         return contentLine;
     }
 
-    let re = new RegExp(`\\s${term}[\\s$]`, 'ig');
-
-    let reComma = new RegExp(`\\s${term},`, 'ig');
-    let reFullStop = new RegExp(`\\s${term}\\.`, 'ig');
+    let re = new RegExp(String.raw`(?=\b)${term}(?=\b)`, 'ig');
 
     let compiledLink = config.glossaryLocation
             .replace('./', `${config.linkPrefix}/`)
             .replace('.md', '');
     let titleSpace = isTitle(contentLine) ? ' ': '';
-    let link = ` [${titleSpace}${term}](/${compiledLink}?id=${linkId})`;
+    let link = `[${titleSpace}${term}](/${compiledLink}?id=${linkId})`;
 
-    return contentLine.replace(reComma, link + ',')
-            .replace(re, link + ' ')
-            .replace(reFullStop, link + '.');
+    return contentLine.replace(re, link);
 }
 
 function isTitle(line) {

--- a/src/main/js/glossary.js
+++ b/src/main/js/glossary.js
@@ -4,21 +4,20 @@ function replaceTermInLine(term, contentLine, linkId, config) {
         return contentLine;
     }
 
-    let re = new RegExp(`\\s(${term})[\\s$]`, 'ig');
+    let re = new RegExp(`\\s${term}[\\s$]`, 'ig');
 
-    let reComma = new RegExp(`\\s(${term}),`, 'ig');
-    let reFullStop = new RegExp(`\\s(${term})\\.`, 'ig');
+    let reComma = new RegExp(`\\s${term},`, 'ig');
+    let reFullStop = new RegExp(`\\s${term}\\.`, 'ig');
 
     let compiledLink = config.glossaryLocation
             .replace('./', `${config.linkPrefix}/`)
             .replace('.md', '');
-    let link = ` [$1](/${compiledLink}?id=${linkId})`;
+    let titleSpace = isTitle(contentLine) ? ' ': '';
+    let link = ` [${titleSpace}${term}](/${compiledLink}?id=${linkId})`;
 
-    let replacement = contentLine.replace(reComma, link + ',')
+    return contentLine.replace(reComma, link + ',')
             .replace(re, link + ' ')
             .replace(reFullStop, link + '.');
-
-    return isTitle(contentLine) ? replacement.replaceAll(`[${term}]`, `[ ${term}]`): replacement;
 }
 
 function isTitle(line) {

--- a/src/main/js/glossary.js
+++ b/src/main/js/glossary.js
@@ -4,15 +4,21 @@ function replaceTermInLine(term, contentLine, linkId, config) {
         return contentLine;
     }
 
-    let re = new RegExp(String.raw`(?=\b)${term}(?=\b)`, 'ig');
+    let re = new RegExp(
+        String.raw`(\[.+?\]\(.+?\))|` + // match MD links in group 1
+        String.raw`(?=\b)${term}(?=\b)` // match given term
+        , 'ig');
 
     let compiledLink = config.glossaryLocation
             .replace('./', `${config.linkPrefix}/`)
             .replace('.md', '');
-    let titleSpace = isTitle(contentLine) ? ' ': '';
-    let link = `[${titleSpace}${term}](/${compiledLink}?id=${linkId})`;
+    let titleSpace = isTitle(contentLine) ? ' ' : '';
+    let createLink = (match) => `[${titleSpace}${match}](/${compiledLink}?id=${
+        linkId} ':class=glossaryLink')`;
 
-    return contentLine.replace(re, link);
+    // only replace regular matches, replace matched group with itself
+    return contentLine.replace(
+        re, (match, group1) => group1 || createLink(match));
 }
 
 function isTitle(line) {

--- a/src/test/js/glossary_test.spec.js
+++ b/src/test/js/glossary_test.spec.js
@@ -183,6 +183,19 @@ describe('Glossary terminology injection', () => {
 
         expect([...result.matchAll('/_glossary\\?id=api')]).toHaveLength(0);
     });
+
+    it('Word replacements do not replace parts of a link', () => {
+        const textWithLink = `
+            This is a link containing the word [Some API link](http://link/to/ API .)
+       `;
+
+        const configuration = defaultGlossifyConfig();
+
+        let result = addLinks(textWithLink, dictionary, configuration);
+
+        expect(result).toContain('This is a link containing the word [Some API link](http://link/to/ API .)');
+        expect([...result.matchAll('/_glossary\\?id=api')]).toHaveLength(0);
+    });
 });
 
 describe('Glossary location', () => {

--- a/src/test/js/glossary_test.spec.js
+++ b/src/test/js/glossary_test.spec.js
@@ -109,6 +109,12 @@ describe('Glossary terminology injection', () => {
         expect(result).toContain('## Information about the [ API](/_glossary?id=api)');
     });
 
+    it('preserves case of linked text', () => {
+        const textWithLink = 'aPi';
+        const result = addLinks(textWithLink, dictionary, config);
+        expect(result).toContain('[aPi](/_glossary?id=api \':class=glossaryLink\')');
+    });
+
     it('Word replacement in title sequences can be disabled', () => {
         const textWithTile = `
             # This is an API title


### PR DESCRIPTION
`addLinks` replaces terms inside already existing markdown links. This PR changes this behavior such, that markdown links are matched by regex and just replaced with itself in `replace` without change.

Further, a test is introduced that shows the wrong behavior and that the fix actually works. The first two commits simplify the regex replacement by:

- matching the term without a group and removing the second replacement
- employing lookahead assertions 